### PR TITLE
Option to override behavior of closing widget when delete is called w…

### DIFF
--- a/lib/passcode_screen.dart
+++ b/lib/passcode_screen.dart
@@ -27,6 +27,7 @@ class PasscodeScreen extends StatefulWidget {
   final Widget bottomWidget;
   final CircleUIConfig circleUIConfig;
   final KeyboardUIConfig keyboardUIConfig;
+  final bool dismissWhenDeleteEmpty;
 
   PasscodeScreen({
     Key key,
@@ -43,6 +44,7 @@ class PasscodeScreen extends StatefulWidget {
     this.titleColor = Colors.white,
     this.backgroundColor,
     this.cancelCallback,
+    this.dismissWhenDeleteEmpty = true,
   }) : super(key: key);
 
   @override
@@ -137,7 +139,9 @@ class _PasscodeScreenState extends State<PasscodeScreen> with SingleTickerProvid
         enteredPasscode = enteredPasscode.substring(0, enteredPasscode.length - 1);
       });
     } else {
-      Navigator.maybePop(context);
+      if (widget.dismissWhenDeleteEmpty) {
+        Navigator.maybePop(context);
+      }
 
       if (widget.cancelCallback != null) {
         widget.cancelCallback();


### PR DESCRIPTION
I'd like to be able to keep the pin code screen up when delete is called, and the entered pin is empty. I created an option to override this behaviour.

The use case is when I'm using it as an auth screen. Making it mandatory to enter the pin to continue. 