### PR TITLE
BUG: Fix debug assertion on ShakeCurve animation.

### DIFF
--- a/lib/shake_curve.dart
+++ b/lib/shake_curve.dart
@@ -7,6 +7,6 @@ class ShakeCurve extends Curve {
   @override
   double transform(double t) {
     //t from 0.0 to 1.0
-    return sin(t * 3 * pi).abs();
+    return sin(t * 2.5 * pi).abs();
   }
 }


### PR DESCRIPTION
Flutter's Curve class requires that the `transform` function map 0 to ~0 and 1
to ~1. The previous ShakeCurve transform function sin(t * 3 * pi).abs(), which
doesn't satisfy this property because sin(3 * pi) is 0, not 1.

Changing the constant from 3 to 2.5 produces the required endpoint value for t
= 1.

Fixes https://github.com/xPutnikx/flutter-passcode/issues/23 .